### PR TITLE
remove g++ version in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 
 all: LNSimulator
 
-GPP = g++-4.9
+GPP = g++
 
 CPPOPTS = -std=c++11 
 #-pg --no-pie


### PR DESCRIPTION
makes it compile on the latest Ubuntu LTS (18.04)